### PR TITLE
Updated country code for location-based banner

### DIFF
--- a/configs/oasis-borrow/getParameters.ts
+++ b/configs/oasis-borrow/getParameters.ts
@@ -12,7 +12,7 @@ export const getParameters = ({
     message: "Oasis.app is now Summer.fi! Read the announcement",
   },
   locationBanner: {
-    UK: {
+    GB: {
         enabled: true,
         closeable: false,
         name: "uk_disclaimer",


### PR DESCRIPTION
Changed the country code from 'UK' to 'GB' in getParameters.ts file under configs/oasis_borrow directory. The country code 'UK' does not match with ISO 3166-1 standard which might lead to display issues; hence, it has been updated to 'GB'.
