### PR TITLE
Add subgraphs base URL

### DIFF
--- a/configs/oasis-borrow/getParameters.ts
+++ b/configs/oasis-borrow/getParameters.ts
@@ -38,4 +38,9 @@ export const getParameters = ({
       BASEMAINNET: "WETH",
     },
   },
+  subgraphs: {
+    baseUrl: notProduction
+      ? "https://graph.staging.summer.fi/subgraphs/name"
+      : "https://graph.staging.summer.fi/subgraphs/name",
+  },
 });


### PR DESCRIPTION
This pull request adds a new subgraphs base URL to the code. The base URL is set to "https://graph.staging.summer.fi/subgraphs/name" for both production and non-production environments. This change allows for easier management and configuration of subgraphs in the code.