### PR TITLE
Enable Satsuma on production

### DIFF
--- a/configs/oasis-borrow/getParameters.ts
+++ b/configs/oasis-borrow/getParameters.ts
@@ -41,6 +41,6 @@ export const getParameters = ({
   subgraphs: {
     baseUrl: notProduction
       ? "https://satsuma.subgraph.staging.oasisapp.dev/subgraphs/name"
-      : "https://graph.staging.summer.fi/subgraphs/name",
+      : "https://satsuma.subgraph.staging.oasisapp.dev/subgraphs/name",
   },
 });


### PR DESCRIPTION
This pull request enables Satsuma on the production environment by updating the `baseUrl` for the subgraphs in the code.