### PR TITLE
Merge only if subgraphs stopped working on prod - Revert "Enable Satsuma on production"

### DIFF
--- a/configs/oasis-borrow/getParameters.ts
+++ b/configs/oasis-borrow/getParameters.ts
@@ -41,6 +41,6 @@ export const getParameters = ({
   subgraphs: {
     baseUrl: notProduction
       ? "https://satsuma.subgraph.staging.oasisapp.dev/subgraphs/name"
-      : "https://satsuma.subgraph.staging.oasisapp.dev/subgraphs/name",
+      : "https://graph.staging.summer.fi/subgraphs/name",
   },
 });


### PR DESCRIPTION
Reverts OasisDEX/oazo-configuration#78