### PR TITLE
Add risk ratio parameters to getParameters

### DIFF
--- a/configs/oasis-borrow/getParameters.ts
+++ b/configs/oasis-borrow/getParameters.ts
@@ -37,6 +37,11 @@ export const getParameters = ({
       OPTIMISMMAINNET: "WETH",
       BASEMAINNET: "WETH",
     },
+    riskRatios: {
+      // uses new RiskRatio(new BigNumber(5), RiskRatio.TYPE.COL_RATIO) so its one over the number here
+      minimum: 5,
+      default: 5,
+    },
   },
   subgraphs: {
     baseUrl: notProduction


### PR DESCRIPTION
This pull request adds risk ratio parameters to the `getParameters` function. The risk ratios are set to a minimum and default value of 5.