### PR TITLE
Update minimum LTV in the slider to 1%

### DIFF
--- a/configs/oasis-borrow/getParameters.ts
+++ b/configs/oasis-borrow/getParameters.ts
@@ -39,7 +39,7 @@ export const getParameters = ({
     },
     riskRatios: {
       // uses new RiskRatio(new BigNumber(5), RiskRatio.TYPE.COL_RATIO) so its one over the number here
-      minimum: 5,
+      minimum: 100,
       default: 5,
     },
   },


### PR DESCRIPTION

## Changes 👷‍♀️

- Updates the minimum of the LTV in the slider to 1%
- Keeps the default to 20%
