### PR TITLE
Add wallet rpc addresses

### DIFF
--- a/configs/oasis-borrow/getParameters.ts
+++ b/configs/oasis-borrow/getParameters.ts
@@ -51,6 +51,11 @@ export const getParameters = ({
     ledger: false,
     trezor: true
   },
+  walletRpc: {
+    8453: "https://mainnet.base.org/", // Base
+    10: "https://mainnet.optimism.io/", // Optimism
+    42161: "https://arb1.arbitrum.io/rpc", // Arbitrum
+  },
   subgraphs: {
     baseUrl: notProduction
       ? "https://satsuma.subgraph.staging.oasisapp.dev/subgraphs/name"


### PR DESCRIPTION
Added params for web3onboard rpc:
```
For base: https://mainnet.base.org/
For optimism: https://mainnet.optimism.io/
For Arb: https://arb1.arbitrum.io/rpc
```