### PR TITLE
UseOmniKitLinks

### DIFF
--- a/configs/oasis-borrow/getFeatures.ts
+++ b/configs/oasis-borrow/getFeatures.ts
@@ -81,4 +81,5 @@ export const getFeatures = ({ isStaging: _isStaging }: ConfigHelperType) => ({
   DsProxyMigrationOptimism: false,
   DsProxyMigrationArbitrum: false,
   DsProxyMigrationBase: false,
+  UseOmniKitLinks: false,
 });


### PR DESCRIPTION
UseOmniKitLinks - used in portfolio links handling, currently just for aave/spark