### PR TITLE
Update Morpho banner

### DIFF
--- a/configs/oasis-borrow/getParameters.ts
+++ b/configs/oasis-borrow/getParameters.ts
@@ -11,21 +11,13 @@ export const getParameters = ({
     url: "https://blog.summer.fi/oasis-app-rebrands-to-summer-fi/",
     message: "Oasis.app is now Summer.fi! Read the announcement",
   },
-  announcement: notProduction
-    ? {
-        enabled: true,
-        message:
-          "$MORPHO is now claimable. Claim now from your Summer.fi position. More info",
-        url: "#",
-        icon: "morpho_circle_color",
-      }
-    : {
-        enabled: true,
-        message:
-          "The Sky Ecosystem is here, Upgrade your $DAI to $USDS, your $MKR to $SKY, and deposit to start earning $SKY rewards.",
-        url: "/ethereum/sky/upgrade",
-        icon: "sky",
-      },
+  announcement: {
+    enabled: true,
+    message:
+      "$MORPHO is now claimable. Claim now from your Summer.fi position. More info",
+    url: "https://x.com/summerfinance_/status/1859549734219686226",
+    icon: "morpho_circle_color",
+  },
   locationBanner: {
     GB: {
       enabled: true,


### PR DESCRIPTION
This pull request includes a change to the `configs/oasis-borrow/getParameters.ts` file to update the announcement message and URL. The change ensures that the announcement is always enabled and updates the message and URL to reflect the latest information.

* [`configs/oasis-borrow/getParameters.ts`](diffhunk://#diff-ecbf6cbadf37a716205e686d021c8ef8de118aea0f8ff0b66a20cc525ad15dadL14-L27): Updated the announcement message to "$MORPHO is now claimable. Claim now from your Summer.fi position. More info" and the URL to "https://x.com/summerfinance_/status/1859549734219686226". Removed the conditional logic that displayed a different message and URL in non-production environments.