### PR TITLE
Earn config - every network will always have empty config

### DIFF
--- a/configs/earn-protocol/getFleetConfig.ts
+++ b/configs/earn-protocol/getFleetConfig.ts
@@ -29,6 +29,7 @@ export const getFleetConfig: GetFleetConfig = () => ({
   [NetworkIds.OPTIMISMMAINNET]: emptyConfig,
   [NetworkIds.ARBITRUMMAINNET]: emptyConfig,
   [NetworkIds.BASEMAINNET]: {
+    ...emptyConfig,
     "0x2653014cd3ad332a98b0a80ccf12473740df81c2": {
       name: "Earn McYieldFace USDC",
       slug: "earn-mcyieldface-usdc",


### PR DESCRIPTION
This pull request includes a small change to the `configs/earn-protocol/getFleetConfig.ts` file. The change involves extending the `emptyConfig` object for the `BASEMAINNET` network configuration.

* [`configs/earn-protocol/getFleetConfig.ts`](diffhunk://#diff-3736da1c9b88c948f10ccb5b3498d07d7eb2108c02af405d48144da5ae325e71R32): Added the spread operator to include all properties of `emptyConfig` in the `BASEMAINNET` configuration.