### PR TITLE
Add maintenance flag

### DIFF
--- a/configs/earn-protocol/index.ts
+++ b/configs/earn-protocol/index.ts
@@ -6,5 +6,6 @@ export default function (params: ConfigHelperType) {
   return {
     links: getLinks(params),
     fleetMap: getFleetConfig(),
+    maintenance: false,
   };
 }


### PR DESCRIPTION
This pull request includes a small change to the `configs/earn-protocol/index.ts` file. The change adds a `maintenance` flag to the returned configuration object.

* [`configs/earn-protocol/index.ts`](diffhunk://#diff-23659c17fe049699763e43728ef8177737c0adb491ffa54183d38860c555939dR9): Added a `maintenance` flag set to `false` in the returned configuration object.