### PR TITLE
Refactor fleet configuration for dynamic parameters and vault management

### DIFF
--- a/configs/earn-protocol/getFleetConfig.ts
+++ b/configs/earn-protocol/getFleetConfig.ts
@@ -1,16 +1,18 @@
+import { ConfigHelperType } from "⌨️";
 import { NetworkIds, Risk } from "🤝";
 
 type FleetConfig = {
   [contractAddress: `0x${string}`]: {
     address: `0x${string}` | "";
-    name: string;
-    slug: string;
-    bestFor: string;
-    risk: Risk;
+    name?: string;
+    slug?: string;
+    bestFor?: string;
+    risk?: Risk;
+    disabled?: boolean;
   };
 };
 
-type GetFleetConfig = () => {
+type GetFleetConfig = (params: ConfigHelperType) => {
   [networkId in NetworkIds]: FleetConfig;
 };
 
@@ -23,54 +25,39 @@ const emptyConfig: FleetConfig = {
     slug: "",
     bestFor: "",
     risk: "lower",
+    disabled: false,
   },
 };
 
-export const getFleetConfig: GetFleetConfig = () => ({
+const disableVault = (address: string, flag: boolean) =>
+  flag
+    ? {
+        ...{
+          [address]: {
+            address,
+            disabled: true,
+          },
+        },
+      }
+    : {};
+
+export const getFleetConfig: GetFleetConfig = ({ isProduction }) => ({
   // FLEET ADDRESS SHOULD BE ALL LOWERCASE (unlike this comment)
   [NetworkIds.MAINNET]: {
     ...emptyConfig,
-    "0x5c442ea2a29c0a595f017e1b2bead568d9aa77da": {
-      address: "0x5c442ea2a29c0a595f017e1b2bead568d9aa77da",
-      name: "Mainnet USDC",
-      slug: "mainnet-usdc",
-      bestFor: "Chill earning",
-      risk: "lower",
-    },
-    "0x8faf711962e89047cb26fb4b4f8dbd578069db53": {
-      address: "0x8faf711962e89047cb26fb4b4f8dbd578069db53",
-      name: "Mainnet USDT",
-      slug: "mainnet-usdt",
-      bestFor: "Chill earning",
-      risk: "lower",
-    },
-    "0x125c8d2e0fb1d68cbe27a9ba0b1f2841cbf313da": {
-      address: "0x125c8d2e0fb1d68cbe27a9ba0b1f2841cbf313da",
-      name: "Mainnet WETH",
-      slug: "mainnet-weth",
-      bestFor: "Chill earning",
-      risk: "lower",
-    },
   },
-  [NetworkIds.OPTIMISMMAINNET]: emptyConfig,
+  [NetworkIds.OPTIMISMMAINNET]: {
+    ...emptyConfig,
+  },
   [NetworkIds.ARBITRUMMAINNET]: {
     ...emptyConfig,
-    "0x2653014cd3ad332a98b0a80ccf12473740df81c2": {
-      address: "0x2653014cd3ad332a98b0a80ccf12473740df81c2",
-      name: "Earn McYieldFace USDC",
-      slug: "earn-mcyieldface-usdc",
-      bestFor: "Chill earning",
-      risk: "lower",
-    },
   },
   [NetworkIds.BASEMAINNET]: {
     ...emptyConfig,
-    "0xeb201f4915b6cbff5a01abd866fe6c6a026f224d": {
-      address: "0xeb201f4915b6cbff5a01abd866fe6c6a026f224d",
-      name: "USDC Ya Later",
-      slug: "usdc-ya-later",
-      bestFor: "Earning while asleep",
-      risk: "higher",
-    },
+    ...disableVault("0x64db8f51f1bf7064bb5a361a7265f602d348e0f0", isProduction),
+  },
+  [NetworkIds.SONIC]: {
+    ...emptyConfig,
+    ...disableVault("0x8b8235f12f03c34d9cb064460e234cc2c9a12922", isProduction),
   },
 });

--- a/configs/earn-protocol/index.ts
+++ b/configs/earn-protocol/index.ts
@@ -6,7 +6,7 @@ import { getLinks } from "./getLinks";
 export default function (params: ConfigHelperType) {
   return {
     links: getLinks(params),
-    fleetMap: getFleetConfig(),
+    fleetMap: getFleetConfig(params),
     features: getFeatures(params),
     maintenance: false,
   };

--- a/shared/network.ts
+++ b/shared/network.ts
@@ -9,6 +9,7 @@ export enum Network {
   OPTIMISM = "optimism", // Optimism Layer 2 Mainnet
   ARBITRUM = "arbitrum", // Arbitrum Layer 2 Mainnet
   BASE = "base", // Base Layer 2 Mainnet (Coinbase)
+  SONIC = "sonic",
 }
 
 export enum NetworkIds {
@@ -16,4 +17,5 @@ export enum NetworkIds {
   ARBITRUMMAINNET = 42161,
   OPTIMISMMAINNET = 10,
   BASEMAINNET = 8453,
+  SONIC = 146,
 }


### PR DESCRIPTION
This pull request includes several changes to the `configs/earn-protocol` and `shared` directories to add support for a new network and improve the configuration handling. The most important changes include the addition of the `SONIC` network, modifications to the `FleetConfig` type, and updates to the `getFleetConfig` function to handle disabling vaults based on a new parameter.

Support for new network:

* [`shared/network.ts`](diffhunk://#diff-af1a5ab25a671293fbf32e194c8b74de14a90df5e1c49947d16e3a7a2d557fb0R12-R20): Added `SONIC` to the `Network` enum and `NetworkIds` enum.

Improvements to configuration handling:

* [`configs/earn-protocol/getFleetConfig.ts`](diffhunk://#diff-3736da1c9b88c948f10ccb5b3498d07d7eb2108c02af405d48144da5ae325e71R1-R15): Modified the `FleetConfig` type to make certain fields optional and added a new `disabled` field.
* [`configs/earn-protocol/getFleetConfig.ts`](diffhunk://#diff-3736da1c9b88c948f10ccb5b3498d07d7eb2108c02af405d48144da5ae325e71R28-R61): Updated the `getFleetConfig` function to accept a `ConfigHelperType` parameter and added logic to disable vaults based on the `isProduction` flag.
* [`configs/earn-protocol/index.ts`](diffhunk://#diff-23659c17fe049699763e43728ef8177737c0adb491ffa54183d38860c555939dL9-R9): Passed the `params` argument to the `getFleetConfig` function to ensure it can use the new parameter.