### PR TITLE
Hide USDC higher risk on prod

### DIFF
--- a/configs/earn-protocol/getFleetConfig.ts
+++ b/configs/earn-protocol/getFleetConfig.ts
@@ -51,7 +51,7 @@ const vaultConfig: (props: FleetConfig[`0x${string}`]) => FleetConfig = (
 });
 
 export const getFleetConfig: GetFleetConfig = ({
-  isProduction: _isProduction,
+  isProduction,
 }) => ({
   // FLEET ADDRESS SHOULD BE ALL LOWERCASE ('vaultConfig' takes care of it)
   [NetworkIds.MAINNET]: {
@@ -65,6 +65,7 @@ export const getFleetConfig: GetFleetConfig = ({
       address: "0xe9cda459bed6dcfb8ac61cd8ce08e2d52370cb06", // USDC
       risk: "higher",
       bestFor: "More aggressive strategies",
+      disabled: isProduction,
     }),
   },
   [NetworkIds.OPTIMISMMAINNET]: {


### PR DESCRIPTION
This pull request updates the `getFleetConfig` function in `configs/earn-protocol/getFleetConfig.ts` to enhance configuration handling based on the `isProduction` flag. The most important changes include removing an unused variable and adding a new property to conditionally disable certain configurations in production.

### Configuration updates:
* Removed the unused `_isProduction` variable from the `getFleetConfig` function parameters to simplify the code. (`[configs/earn-protocol/getFleetConfig.tsL54-R54](diffhunk://#diff-3736da1c9b88c948f10ccb5b3498d07d7eb2108c02af405d48144da5ae325e71L54-R54)`)
* Added a `disabled` property to the configuration object, which dynamically disables certain configurations when `isProduction` is `true`. (`[configs/earn-protocol/getFleetConfig.tsR68](diffhunk://#diff-3736da1c9b88c948f10ccb5b3498d07d7eb2108c02af405d48144da5ae325e71R68)`)
