### PR TITLE
Enable USDC ethereum High Risk on prod

### DIFF
--- a/configs/earn-protocol/getFleetConfig.ts
+++ b/configs/earn-protocol/getFleetConfig.ts
@@ -51,7 +51,7 @@ const vaultConfig: (props: FleetConfig[`0x${string}`]) => FleetConfig = (
 });
 
 export const getFleetConfig: GetFleetConfig = ({
-  isProduction,
+  isProduction: _isProduction,
 }) => ({
   // FLEET ADDRESS SHOULD BE ALL LOWERCASE ('vaultConfig' takes care of it)
   [NetworkIds.MAINNET]: {
@@ -65,7 +65,6 @@ export const getFleetConfig: GetFleetConfig = ({
       address: "0xe9cda459bed6dcfb8ac61cd8ce08e2d52370cb06", // USDC
       risk: "higher",
       bestFor: "More aggressive strategies",
-      disabled: isProduction,
     }),
   },
   [NetworkIds.OPTIMISMMAINNET]: {


### PR DESCRIPTION
This pull request includes a minor update to the `getFleetConfig` function in `configs/earn-protocol/getFleetConfig.ts`. The changes involve renaming the `isProduction` parameter and removing its usage in the configuration logic.

Key changes:

* Renamed the `isProduction` parameter to `_isProduction` to indicate that it is no longer used within the function. (`[configs/earn-protocol/getFleetConfig.tsL54-R54](diffhunk://#diff-3736da1c9b88c948f10ccb5b3498d07d7eb2108c02af405d48144da5ae325e71L54-R54)`)
* Removed the `disabled` property, which previously relied on the `isProduction` parameter, from the configuration for the `NetworkIds.MAINNET` fleet. (`[configs/earn-protocol/getFleetConfig.tsL68](diffhunk://#diff-3736da1c9b88c948f10ccb5b3498d07d7eb2108c02af405d48144da5ae325e71L68)`)