### PR TITLE
AdrollPixelScript

### DIFF
--- a/configs/earn-protocol/getFeatures.ts
+++ b/configs/earn-protocol/getFeatures.ts
@@ -11,4 +11,5 @@ export const getFeatures = ({
   VaultSwitching: true,
   BeachClub: isStaging || isDevelopment,
   Institutions: isStaging || isDevelopment,
+  AdrollPixelScript: !isProduction,
 });


### PR DESCRIPTION
Adds a new feature flag for `AdrollPixelScript` that is enabled only when the environment is not production.