### PR TITLE
Enable BeachClub

### DIFF
--- a/configs/earn-protocol/getFeatures.ts
+++ b/configs/earn-protocol/getFeatures.ts
@@ -9,7 +9,7 @@ export const getFeatures = ({
   Send: true,
   FilterZeroTokenVaults: isProduction, // filter out zero token vaults on production
   VaultSwitching: true,
-  BeachClub: isStaging || isDevelopment,
+  BeachClub: true,
   Institutions: isStaging || isDevelopment,
   AdrollPixelScript: !isProduction,
 });


### PR DESCRIPTION
This pull request updates the feature flags configuration in `configs/earn-protocol/getFeatures.ts` to enable the `BeachClub` feature universally, regardless of the environment.