### PR TITLE
Add Game feature toggle

### DIFF
--- a/configs/earn-protocol/getFeatures.ts
+++ b/configs/earn-protocol/getFeatures.ts
@@ -12,4 +12,5 @@ export const getFeatures = ({
   BeachClub: true,
   Institutions: isStaging || isDevelopment,
   AdrollPixelScript: !isProduction,
+  Game: !isProduction,
 });


### PR DESCRIPTION
This pull request adds a new feature flag to the `getFeatures` configuration in the `earn-protocol` project.

Feature flag updates:

* [`configs/earn-protocol/getFeatures.ts`](diffhunk://#diff-285bf0658e2641f6fe4b195a5be4375444abcc5967bf41619d6504d18da4c046R15): Added a new `Game` feature flag that is enabled when the environment is not production.