### PR TITLE
Add Team feature toggle to getFeatures configuration

### DIFF
--- a/configs/earn-protocol/getFeatures.ts
+++ b/configs/earn-protocol/getFeatures.ts
@@ -11,6 +11,7 @@ export const getFeatures = ({
   VaultSwitching: true,
   BeachClub: true,
   Institutions: isStaging || isDevelopment,
+  Team: isStaging || isDevelopment,
   AdrollPixelScript: !isProduction,
   Game: true,
 });


### PR DESCRIPTION
Introduce a feature toggle for the Team feature in the getFeatures configuration, enabling it for staging and development environments.