### PR TITLE
Update bannerMessage with provider issue notification

### DIFF
--- a/configs/earn-protocol/index.ts
+++ b/configs/earn-protocol/index.ts
@@ -9,7 +9,7 @@ export default function (params: ConfigHelperType) {
     fleetMap: getFleetConfig(params),
     features: getFeatures(params),
     maintenance: false,
-    bannerMessage: "",
+    bannerMessage: "We are aware of an issue with our subgraph provider causing Mainnet balances (including deposits and withdrawals) to not update correctly. Our team is monitoring the situation.",
     deployment: params,
   };
 }


### PR DESCRIPTION
This pull request makes a minor update to the `configs/earn-protocol/index.ts` configuration file. The change updates the `bannerMessage` to inform users about an ongoing issue with the subgraph provider affecting Mainnet balance updates.

* Updated the `bannerMessage` to notify users about Mainnet balance update issues due to a subgraph provider problem.