### PR TITLE
Add SuperLazyVaults feature toggle

### DIFF
--- a/configs/earn-protocol/getFeatures.ts
+++ b/configs/earn-protocol/getFeatures.ts
@@ -9,5 +9,6 @@ export const getFeatures = ({ isProduction }: ConfigHelperType) => ({
   Institutions: true,
   Team: true,
   AdrollPixelScript: !isProduction,
+  SuperLazyVaults: !isProduction,
   Game: true,
 });


### PR DESCRIPTION
This pull request introduces a minor update to the feature flag configuration. It adds a new feature flag to control the availability of the `SuperLazyVaults` feature, enabling it only in non-production environments.

- Feature flag update:
  * Added the `SuperLazyVaults` feature flag to the `getFeatures` configuration, set to be enabled only when `isProduction` is false.