### PR TITLE
Add new address to the Tos whitelist

### DIFF
--- a/configs/earn-protocol/getTosWhitelist.ts
+++ b/configs/earn-protocol/getTosWhitelist.ts
@@ -1,3 +1,4 @@
 export const getTosWhitelist = () => ([
   '0xCe6ca762a8c2dd1483ec7dF714CEA751d03260b2',
+  '0xdb6e9e7390e9acc34619e56efa48ade01cff6f12',
 ].map(address => address.toLowerCase()));


### PR DESCRIPTION
This pull request adds a new address to the whitelist in the `getTosWhitelist` function for the Earn Protocol. This update ensures that the newly added address will be recognized as whitelisted by the system.

* Added `0xdb6e9e7390e9acc34619e56efa48ade01cff6f12` to the whitelist returned by `getTosWhitelist` in `configs/earn-protocol/getTosWhitelist.ts`.