### PR TITLE
Add StakingV2 feature toggle for production

### DIFF
--- a/configs/earn-protocol/getFeatures.ts
+++ b/configs/earn-protocol/getFeatures.ts
@@ -11,4 +11,5 @@ export const getFeatures = ({ isProduction }: ConfigHelperType) => ({
   AdrollPixelScript: !isProduction,
   SuperLazyVaults: !isProduction,
   Game: true,
+  StakingV2: !isProduction,
 });


### PR DESCRIPTION
This pull request introduces a minor configuration update to the feature flags in the `getFeatures` function. The main change is the addition of a new feature flag.

* Added the `StakingV2` feature flag, which will be enabled only in non-production environments in the `getFeatures` function (`configs/earn-protocol/getFeatures.ts`).