### PR TITLE
Add DcaEnabled feature toggle based on environment

### DIFF
--- a/configs/earn-protocol/getFeatures.ts
+++ b/configs/earn-protocol/getFeatures.ts
@@ -15,4 +15,5 @@ export const getFeatures = ({ isProduction }: ConfigHelperType) => ({
   UseSumrCoingeckoPrice: true,
   SumrCoingeckoTokenID: "summer-2",
   DaoManagedVaults: true,
+  DcaEnabled: !isProduction,
 });


### PR DESCRIPTION
This pull request introduces a minor configuration update to the feature flags in `getFeatures.ts`. The main change is enabling the `DcaEnabled` feature flag only in non-production environments.