### PR TITLE
Enable RWA feature based on production environment

### DIFF
--- a/configs/earn-protocol/getFeatures.ts
+++ b/configs/earn-protocol/getFeatures.ts
@@ -16,4 +16,5 @@ export const getFeatures = ({ isProduction }: ConfigHelperType) => ({
   SumrCoingeckoTokenID: "summer-2",
   DaoManagedVaults: true,
   DcaEnabled: !isProduction,
+  RwaEnabled: !isProduction,
 });


### PR DESCRIPTION
This pull request introduces a small configuration update to the `getFeatures` function. The change enables the `RwaEnabled` feature flag only in non-production environments.